### PR TITLE
Update scikit-learn version to 1.7.2

### DIFF
--- a/kaggle_requirements.txt
+++ b/kaggle_requirements.txt
@@ -125,7 +125,7 @@ ray
 rgf-python
 s3fs
 # b/302136621: Fix eli5 import for learntools
-scikit-learn==1.2.2
+scikit-learn==1.7.2
 # Scikit-learn accelerated library for x86
 scikit-learn-intelex>=2023.0.1
 scikit-multilearn


### PR DESCRIPTION
This updates scikit-learn to the most recent version.

It is the first time I've contributed to this repo 👋  Interested to see what happens/breaks with the newest version. As a scikit-learn maintainer it makes me happy if people are using the latest version of scikit-learn. All the work that has gone into it should benefit someone :D

How do I use the comment above the scikit-learn entry in the requirements file to find out what it is referring to? I guess it is referencing a bug or discussion somewhere? I had a brief look at the `learntools` PyPI page and there hasn't been a release in about two years. This probably explains why it doesn't work with new versions of scikit-learn. What is the process for figuring out when to favour newer scikit-learn versions over keeping learntools? Keeping packages that used to be part of the image is useful, but having new versions of other packages is also useful. So we need some kind of tradeoff :-/